### PR TITLE
fix: Change from gridResponsive to flex forms on MintSteps

### DIFF
--- a/src/components/form/formWithSteps/FormWithSteps.tsx
+++ b/src/components/form/formWithSteps/FormWithSteps.tsx
@@ -18,7 +18,7 @@ import { useSizeSM } from '@/src/hooks/useSize'
 type FormWithStepsProps = {
   stepSchemas: (AnyZodObject | ZodEffects<any, any, any>)[]
   stepNames: string[]
-  formGridLayout: DataGrid[][]
+  formGridLayout?: DataGrid[][]
   formLayout?: FormLayoutType
   formFieldProps?: Record<string, any>[]
   onSubmit: (data: any) => void
@@ -188,9 +188,13 @@ export function FormWithSteps({
                 <CustomFormFromSchemaWithoutSubmit
                   formProps={{
                     layout: formLayout,
-                    gridStructure: formGridLayout[activeStep],
                     buttonLabel: 'Next',
                     buttonRef: formButtonRef,
+                    ...(formLayout === 'gridResponsive' && formGridLayout
+                      ? {
+                          gridStructure: formGridLayout[activeStep],
+                        }
+                      : {}),
                   }}
                   onSubmit={handleSubmitNext}
                   props={formFieldProps ? formFieldProps[activeStep] : undefined}

--- a/src/pagePartials/badge/mint/MintSteps.tsx
+++ b/src/pagePartials/badge/mint/MintSteps.tsx
@@ -182,8 +182,7 @@ export default function MintSteps({ costs, evidenceSchema, onSubmit, txState }: 
             },
           },
         ]}
-        formGridLayout={formGridLayout}
-        formLayout={'gridResponsive'}
+        formLayout={'flex'}
         formSubmitReview={handleFormPreview}
         hideSubmit={txState !== TransactionStates.none}
         onStepChanged={(sn) => setCurrentStep(sn)}


### PR DESCRIPTION
# Description

Temporal fix, using `flex` form instead of `gridResponsive` until we store the form layout
