### PR TITLE
feat: Make the link evidence displays with target blank

### DIFF
--- a/src/components/displayEvidence/DisplayLink.tsx
+++ b/src/components/displayEvidence/DisplayLink.tsx
@@ -17,7 +17,11 @@ export function DisplayLink({ label, placeholder, value }: DisplayLinkProps) {
   return (
     <FormField
       formControl={
-        <Typography component={'a'} href={protocolRegex.test(value) ? value : `https://${value}`}>
+        <Typography
+          component={'a'}
+          href={protocolRegex.test(value) ? value : `https://${value}`}
+          target={'_blank'}
+        >
           {value}
         </Typography>
       }


### PR DESCRIPTION
# Description

- The evidence modal link now opens a tab ("target=_blank")



