### PR TITLE
fix: Key with estrange chars

### DIFF
--- a/src/components/form/helpers/customSchemas.ts
+++ b/src/components/form/helpers/customSchemas.ts
@@ -17,6 +17,18 @@ export const CheckBoxSchema = createUniqueFieldSchema(
   'CheckBoxSchema',
 )
 
+export const LinkSchema = createUniqueFieldSchema(
+  z
+    .string({
+      required_error: 'Is required',
+      invalid_type_error: 'Must be a link',
+    })
+    .refine((value) => value.startsWith('http'), {
+      message: 'You need to add valid url.',
+    }),
+  'LinkSchema',
+)
+
 export const AgreementSchema = createUniqueFieldSchema(
   z
     .boolean({

--- a/src/components/form/helpers/schemaToComponent.ts
+++ b/src/components/form/helpers/schemaToComponent.ts
@@ -26,6 +26,7 @@ import {
   ImageSchema,
   KlerosDynamicFields,
   KlerosFieldTypeSchema,
+  LinkSchema,
   LongTextSchema,
   NumberSchema,
   OptionalFileSchema,
@@ -38,6 +39,7 @@ import KlerosDynamicFieldsCreator from '@/src/components/form/klerosDynamicFormF
 // Create the mapping btw each schema type to the React component used for it
 export const mappingSchemaToComponents = [
   [z.string(), TextField],
+  [LinkSchema, TextField],
   [CheckBoxSchema, CheckBox],
   [NumberSchema, NumberField],
   [AddressSchema, TextField],

--- a/src/components/form/helpers/validators.ts
+++ b/src/components/form/helpers/validators.ts
@@ -7,6 +7,7 @@ import {
   CheckBoxSchema,
   FileSchema,
   ImageSchema,
+  LinkSchema,
   LongTextSchema,
   NumberSchema,
   TwitterSchema,
@@ -19,13 +20,6 @@ const zText = z
     invalid_type_error: 'Must be an string',
   })
   .min(2, { message: 'Text field most have at least 2 characters.' })
-
-const zLink = z
-  .string({
-    required_error: 'Is required',
-    invalid_type_error: 'Must be a link',
-  })
-  .startsWith('http')
 
 export function isEmail(email: string) {
   return String(email)
@@ -44,7 +38,7 @@ function getZValidator(fieldType: KLEROS_LIST_TYPES) {
     case KLEROS_LIST_TYPES.TWITTER_USER_ID:
       return TwitterSchema
     case KLEROS_LIST_TYPES.LINK:
-      return zLink
+      return LinkSchema
     case KLEROS_LIST_TYPES.LONG_TEXT:
       return LongTextSchema
     case KLEROS_LIST_TYPES.TEXT:
@@ -76,8 +70,8 @@ export function isMetadataColumnArray(obj: any): obj is MetadataColumn[] {
 
 export default function klerosSchemaFactory(fields: MetadataColumn[]) {
   const shape: { [key: string]: ZodType } = {}
-  fields.forEach((field) => {
-    shape[field.label] = getZValidator(field.type).describe(
+  fields.forEach((field, i) => {
+    shape[`${field.type}-${i}`] = getZValidator(field.type).describe(
       `${field.label} // ${field.description}`,
     )
     //Magic explained here: https://github.com/iway1/react-ts-form#qol


### PR DESCRIPTION
# Description

Now we use as the key on the schema the `FieldType + Index` to prevent strange chars to be used as a key.
