### PR TITLE
fix: details for badge mint cost

### DIFF
--- a/pages/badge/mint/[modelId].tsx
+++ b/pages/badge/mint/[modelId].tsx
@@ -111,7 +111,7 @@ const MintBadgeType: NextPageWithLayout = () => {
           costs={{
             mintCost: formatUnits(creatorFee, 18),
             totalMintCost: formatUnits(mintValue, 18),
-            klerosCost: formatUnits(0, 18), // TODO fix this by checking the deposit cost. It has to be a dynamic call to klerosController
+            klerosCost: formatUnits(mintValue.sub(creatorFee), 18),
           }}
           evidenceSchema={CreateBadgeSchema}
           onSubmit={onSubmit}


### PR DESCRIPTION
# Description

This PR closes #107 by fixing the details for the badge cost shown on the mint badge page.


<img width="445" alt="image" src="https://github.com/thebadge/thebadge-dapp/assets/4376509/d377d449-937e-4929-b87a-0dc35e213552">

<img width="445" alt="image" src="https://github.com/thebadge/thebadge-dapp/assets/4376509/6d26867c-268e-4dce-9f21-af058acb828f">
