### PR TITLE
feat: Add CTA on NoResult list inside profile

### DIFF
--- a/i18n/translations.en.json
+++ b/i18n/translations.en.json
@@ -150,7 +150,8 @@
       "title": "Created badge models",
       "badgesCreatedNoResults": "You don't have any badge models created...",
       "explorerBadgeCost": "Cost:",
-      "explorerBadgeMinted": "Minted: "
+      "explorerBadgeMinted": "Minted: ",
+      "create": "Create a Badge Model"
     },
     "badgesToCurate": "Browse other badges to curate",
     "createdBadges": "Earn by creating new badges",

--- a/i18n/translations.en.json
+++ b/i18n/translations.en.json
@@ -143,7 +143,8 @@
     "badgesYouOwn": {
       "title": "Badges that you own",
       "shared_title": "Badges that the user own",
-      "noResults": "You don't have any badges that match these filters..."
+      "noResults": "You don't have any badges that match these filters...",
+      "mint": "Mint a badge"
     },
     "badgesCreated": {
       "title": "Created badge models",
@@ -166,7 +167,8 @@
       "viewAll": "View details",
       "lastActivity": "Last Activity",
       "submissionChallenge": "You have challenged the submission of this badge",
-      "removalChallenge": "You have requested the removal of this badge"
+      "removalChallenge": "You have requested the removal of this badge",
+      "curate": "Curate a badge"
     },
     "verified": "Verified user"
   },

--- a/pages/badge/explorer.tsx
+++ b/pages/badge/explorer.tsx
@@ -87,6 +87,7 @@ const ExploreBadgeTypes: NextPageWithLayout = () => {
         preview={renderSelectedBadgePreview()}
         search={search}
         title={t('explorer.title')}
+        titleColor={colors.blue}
       >
         {badgeModels.length > 0 ? (
           badgeModels.map((bt, i) => {

--- a/src/pagePartials/profile/Profile.tsx
+++ b/src/pagePartials/profile/Profile.tsx
@@ -57,21 +57,19 @@ const Profile = () => {
               {t('profile.tab2')}
             </Typography>
           </LinkWithTranslation>
-          {user?.isCreator && (
-            <LinkWithTranslation
-              pathname={`/profile`}
-              queryParams={{ filter: ProfileFilter.CREATED_BADGES }}
+          <LinkWithTranslation
+            pathname={`/profile`}
+            queryParams={{ filter: ProfileFilter.CREATED_BADGES }}
+          >
+            <Typography
+              color={
+                selectedFilter === ProfileFilter.CREATED_BADGES ? 'text.primary' : 'text.disabled'
+              }
+              textTransform="uppercase"
             >
-              <Typography
-                color={
-                  selectedFilter === ProfileFilter.CREATED_BADGES ? 'text.primary' : 'text.disabled'
-                }
-                textTransform="uppercase"
-              >
-                {t('profile.tab3')}
-              </Typography>
-            </LinkWithTranslation>
-          )}
+              {t('profile.tab3')}
+            </Typography>
+          </LinkWithTranslation>
         </Box>
       </Stack>
 

--- a/src/pagePartials/profile/created/BadgesCreatedSection.tsx
+++ b/src/pagePartials/profile/created/BadgesCreatedSection.tsx
@@ -1,7 +1,9 @@
+import { useRouter } from 'next/router'
 import React, { useState } from 'react'
 
+import { AddressZero } from '@ethersproject/constants'
 import { Box, Stack, Typography, styled } from '@mui/material'
-import { colors } from '@thebadge/ui-library'
+import { ButtonV2, colors } from '@thebadge/ui-library'
 import { formatUnits } from 'ethers/lib/utils'
 import { useTranslation } from 'next-export-i18n'
 
@@ -34,11 +36,11 @@ const StyledBadgeContainer = styled(MiniBadgePreviewContainer)(({ theme }) => {
 
 export default function BadgesCreatedSection() {
   const { t } = useTranslation()
+  const router = useRouter()
   const { address } = useWeb3Connection()
   const [items, setItems] = useState<React.ReactNode[]>([])
   const [loading, setLoading] = useState<boolean>(false)
   const gql = useSubgraph()
-  if (!address) return null
 
   const search = async (
     selectedFilters: Array<ListFilter>,
@@ -47,7 +49,7 @@ export default function BadgesCreatedSection() {
   ) => {
     setLoading(true)
     // TODO filter badges with: selectedFilters, selectedCategory, textSearch
-    const userCreatedBadges = await gql.userCreatedBadges({ ownerAddress: address })
+    const userCreatedBadges = await gql.userCreatedBadges({ ownerAddress: address ?? AddressZero })
     const badgeModels = userCreatedBadges?.user?.createdBadgeModels || []
 
     const badgesLayouts = badgeModels.map((badgeModel) => {
@@ -80,7 +82,6 @@ export default function BadgesCreatedSection() {
   return (
     <RequiredCreatorAccess>
       <FilteredList
-        // categories={['Category 1', 'Category 2', 'Category 3']}
         filters={[]}
         loading={loading}
         loadingColor={'primary'}
@@ -94,6 +95,14 @@ export default function BadgesCreatedSection() {
         ) : (
           <Stack>
             <NoResultsAnimated errorText={t('profile.badgesCreated.badgesCreatedNoResults')} />
+            <ButtonV2
+              backgroundColor={colors.transparent}
+              fontColor={colors.pink}
+              onClick={() => router.push('/badge/model/create')}
+              sx={{ m: 'auto' }}
+            >
+              <Typography>{t('profile.badgesYouOwn.create')}</Typography>
+            </ButtonV2>
           </Stack>
         )}
       </FilteredList>

--- a/src/pagePartials/profile/myProfile/BadgesYouOwnList.tsx
+++ b/src/pagePartials/profile/myProfile/BadgesYouOwnList.tsx
@@ -1,26 +1,23 @@
 import { useRouter } from 'next/navigation'
 import React, { useState } from 'react'
 
-import { Box, Stack } from '@mui/material'
+import { Box, Stack, Typography } from '@mui/material'
+import { ButtonV2, colors } from '@thebadge/ui-library'
 import { useTranslation } from 'next-export-i18n'
 
 import { NoResultsAnimated } from '@/src/components/assets/animated/NoResults'
 import FilteredList, { ListFilter } from '@/src/components/helpers/FilteredList'
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
-import { useContractInstance } from '@/src/hooks/useContractInstance'
-import useTransaction from '@/src/hooks/useTransaction'
 import MiniBadgeModelPreview from '@/src/pagePartials/badge/MiniBadgeModelPreview'
 import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 import getHighlightColorByStatus from '@/src/utils/badges/getHighlightColorByStatus'
 import { BadgeStatus, Badge_Filter } from '@/types/generated/subgraph'
-import { TheBadge__factory } from '@/types/generated/typechain'
 
 type Props = {
   address: string
 }
 export default function BadgesYouOwnList({ address }: Props) {
   const { t } = useTranslation()
-  const { sendTx } = useTransaction()
   const router = useRouter()
   const { address: connectedWalletAddress } = useWeb3Connection()
 
@@ -29,16 +26,7 @@ export default function BadgesYouOwnList({ address }: Props) {
   const [items, setItems] = useState<React.ReactNode[]>([])
   const [loading, setLoading] = useState<boolean>(false)
 
-  const theBadge = useContractInstance(TheBadge__factory, 'TheBadge')
   const gql = useSubgraph()
-
-  async function handleClaimIt(badgeId: string, address: string) {
-    const transaction = await sendTx(() => theBadge.claim(badgeId, '0x'))
-
-    if (transaction) {
-      await transaction.wait()
-    }
-  }
 
   const filters: Array<ListFilter<BadgeStatus>> = [
     {
@@ -96,7 +84,6 @@ export default function BadgesYouOwnList({ address }: Props) {
 
   return (
     <FilteredList
-      // categories={['Category 1', 'Category 2', 'Category 3']}
       filters={filters}
       loading={loading}
       loadingColor={'blue'}
@@ -105,13 +92,23 @@ export default function BadgesYouOwnList({ address }: Props) {
       title={
         isLoggedInUser ? t('profile.badgesYouOwn.title') : t('profile.badgesYouOwn.shared_title')
       }
-      titleColor={'blue'}
+      titleColor={colors.blue}
     >
       {items.length > 0 ? (
         items
       ) : (
         <Stack>
           <NoResultsAnimated errorText={t('profile.badgesYouOwn.noResults')} />
+          {isLoggedInUser && (
+            <ButtonV2
+              backgroundColor={colors.transparent}
+              fontColor={colors.blue}
+              onClick={() => router.push('/badge/mint')}
+              sx={{ m: 'auto' }}
+            >
+              <Typography>{t('profile.badgesYouOwn.mint')}</Typography>
+            </ButtonV2>
+          )}
         </Stack>
       )}
     </FilteredList>

--- a/src/pagePartials/profile/myProfile/BadgesYouOwnList.tsx
+++ b/src/pagePartials/profile/myProfile/BadgesYouOwnList.tsx
@@ -103,7 +103,7 @@ export default function BadgesYouOwnList({ address }: Props) {
             <ButtonV2
               backgroundColor={colors.transparent}
               fontColor={colors.blue}
-              onClick={() => router.push('/badge/mint')}
+              onClick={() => router.push('/badge/explorer')}
               sx={{ m: 'auto' }}
             >
               <Typography>{t('profile.badgesYouOwn.mint')}</Typography>

--- a/src/pagePartials/profile/reviewing/BadgesIAmReviewingSection.tsx
+++ b/src/pagePartials/profile/reviewing/BadgesIAmReviewingSection.tsx
@@ -1,9 +1,10 @@
+import { useRouter } from 'next/navigation'
 import React, { RefObject, createRef, useState } from 'react'
 
 import ArrowBackIosOutlinedIcon from '@mui/icons-material/ArrowBackIosOutlined'
 import ArrowForwardIosOutlinedIcon from '@mui/icons-material/ArrowForwardIosOutlined'
 import { Box, IconButton, Stack, Typography } from '@mui/material'
-import { colors } from '@thebadge/ui-library'
+import { ButtonV2, colors } from '@thebadge/ui-library'
 import { useTranslation } from 'next-export-i18n'
 
 import { NoResultsAnimated } from '@/src/components/assets/animated/NoResults'
@@ -39,6 +40,7 @@ const filters: Array<ListFilter> = [
 export default function BadgesIAmReviewingSection() {
   const { t } = useTranslation()
   const { address } = useWeb3Connection()
+  const router = useRouter()
   const gql = useSubgraph()
 
   const [badgesIamReviewing, setItems] = useState<Badge[]>([])
@@ -134,6 +136,14 @@ export default function BadgesIAmReviewingSection() {
         ) : (
           <Stack>
             <NoResultsAnimated errorText={t('profile.badgesIAmReviewing.noResults')} />
+            <ButtonV2
+              backgroundColor={colors.transparent}
+              fontColor={colors.green}
+              onClick={() => router.push('/badge/mint')}
+              sx={{ m: 'auto' }}
+            >
+              <Typography>{t('profile.badgesIAmReviewing.curate')}</Typography>
+            </ButtonV2>
           </Stack>
         )}
       </FilteredList>

--- a/src/pagePartials/profile/reviewing/BadgesIAmReviewingSection.tsx
+++ b/src/pagePartials/profile/reviewing/BadgesIAmReviewingSection.tsx
@@ -139,7 +139,7 @@ export default function BadgesIAmReviewingSection() {
             <ButtonV2
               backgroundColor={colors.transparent}
               fontColor={colors.green}
-              onClick={() => router.push('/badge/mint')}
+              onClick={() => router.push('/badge/curate')}
               sx={{ m: 'auto' }}
             >
               <Typography>{t('profile.badgesIAmReviewing.curate')}</Typography>


### PR DESCRIPTION

# Description
Add CTA to improve the navigation from non-result list, to help the user to mint/curate badges, also fix Title colors on explorer and BadgesYouOwnList.tsx

