### PR TITLE
fix: issues on change chain

### DIFF
--- a/pages/badge/explorer.tsx
+++ b/pages/badge/explorer.tsx
@@ -32,6 +32,7 @@ const ExploreBadgeTypes: NextPageWithLayout = () => {
   const badgeModelsElementRefs: RefObject<HTMLLIElement>[] = badgeModels.map(() =>
     createRef<HTMLLIElement>(),
   )
+
   const { selectNext, selectPrevious } = useListItemNavigation(
     setSelectedBadgeModel,
     badgeModelsElementRefs,

--- a/src/components/helpers/FilteredList.tsx
+++ b/src/components/helpers/FilteredList.tsx
@@ -21,6 +21,7 @@ import { Loading } from '@/src/components/loading/Loading'
 import { SpinnerColors } from '@/src/components/loading/Spinner'
 import TBSearchField from '@/src/components/select/SearchField'
 import TBadgeSelect from '@/src/components/select/Select'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 import { useColorMode } from '@/src/providers/themeProvider'
 
 export type ListFilter<K = unknown> = {
@@ -86,6 +87,8 @@ export default function FilteredList({
   const { t } = useTranslation()
 
   const { mode } = useColorMode()
+  const chainId = useChainId()
+
   const defaultSelectedFilters = useMemo(() => filters.filter((f) => f.defaultSelected), [filters])
   const [selectedFilters, setSelectedFilters] = useState<ListFilter[]>(defaultSelectedFilters)
   const [selectedCategory, setSelectedCategory] = useState<string>('')
@@ -111,6 +114,12 @@ export default function FilteredList({
     onSearch(selectedFilters, selectedCategory, textSearch)
 
   const refresh = () => onSearch(selectedFilters, selectedCategory)
+
+  useEffect(() => {
+    // Not the best, but it's working... Feel free to recommend something better
+    refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chainId])
 
   const isFilterSelected = (filter: ListFilter) => {
     return !!selectedFilters.find((f) => f.title === filter.title)

--- a/src/components/helpers/ModalSwitchNetwork.tsx
+++ b/src/components/helpers/ModalSwitchNetwork.tsx
@@ -30,7 +30,6 @@ export const ModalSwitchNetwork: React.FC<ModalSwitchNetwork> = ({ onClose, ...r
                 color="primary"
                 key={index}
                 onClick={() => {
-                  setAppChainId(item.chainId)
                   pushNetwork({ chainId: item.chainIdHex })
                   onClose()
                 }}

--- a/src/hooks/subgraph/useBadgeById.tsx
+++ b/src/hooks/subgraph/useBadgeById.tsx
@@ -2,6 +2,7 @@ import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
 import { getFromIPFS } from '@/src/hooks/subgraph/utils'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 import { BadgeMetadata, BadgeModelMetadata } from '@/types/badges/BadgeMetadata'
 import { BackendFileResponse } from '@/types/utils'
 
@@ -12,8 +13,9 @@ import { BackendFileResponse } from '@/types/utils'
  */
 export default function useBadgeById(badgeId: string) {
   const gql = useSubgraph()
+  const chainId = useChainId()
 
-  return useSWR(badgeId.length ? `Badge:${badgeId}` : null, async (_badgeId: string) => {
+  return useSWR(badgeId.length ? [`Badge:${badgeId}`, badgeId, chainId] : null, async () => {
     const badgeResponse = await gql.badgeById({ id: badgeId })
 
     const badge = badgeResponse.badge

--- a/src/hooks/subgraph/useBadgeKlerosMetadata.tsx
+++ b/src/hooks/subgraph/useBadgeKlerosMetadata.tsx
@@ -4,6 +4,7 @@ import { BadgeModelHooksOptions } from '@/src/hooks/subgraph/types'
 import useBadgeById from '@/src/hooks/subgraph/useBadgeById'
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
 import { getFromIPFS } from '@/src/hooks/subgraph/utils'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 import { BadgeEvidenceMetadata } from '@/types/badges/BadgeMetadata'
 import { KlerosBadgeRequest, KlerosRequestType } from '@/types/generated/subgraph'
 
@@ -17,11 +18,16 @@ export function useBadgeKlerosMetadata(badgeId: string, options?: BadgeModelHook
   // It's going to do the fetch if it has ID and skip option on false
   const fetchIt = !options?.skip && badgeId.length
   const gql = useSubgraph()
-  return useSWR(fetchIt ? [`BadgeKlerosMetadata:${badgeId}`, badgeId] : null, async ([, _id]) => {
-    const badgeKleros = await gql.badgeKlerosMetadataById({ id: _id })
+  const chainId = useChainId()
 
-    return badgeKleros.badgeKlerosMetaData
-  })
+  return useSWR(
+    fetchIt ? [`BadgeKlerosMetadata:${badgeId}`, badgeId, chainId] : null,
+    async ([, _id]) => {
+      const badgeKleros = await gql.badgeKlerosMetadataById({ id: _id })
+
+      return badgeKleros.badgeKlerosMetaData
+    },
+  )
 }
 
 /**
@@ -31,12 +37,13 @@ export function useBadgeKlerosMetadata(badgeId: string, options?: BadgeModelHook
  * @param options
  */
 export function useEvidenceBadgeKlerosMetadata(badgeId: string, options?: BadgeModelHooksOptions) {
+  const chainId = useChainId()
   const badge = useBadgeById(badgeId)
   const badgeKlerosMetadata = useBadgeKlerosMetadata(badgeId, options)
   // It's going to do the fetch if it has ID and skip option on false
   const fetchIt = !options?.skip && badgeId.length
   return useSWR(
-    fetchIt ? [`EvidenceBadgeKlerosMetadata:${badgeId}`, badgeId, badge.data?.id] : null,
+    fetchIt ? [`EvidenceBadgeKlerosMetadata:${badgeId}`, badgeId, badge.data?.id, chainId] : null,
     async ([,]) => {
       if (!badgeKlerosMetadata.data?.requests) {
         throw 'There was not possible to get the needed metadata. Try again in some minutes.'

--- a/src/hooks/subgraph/useBadgeModel.tsx
+++ b/src/hooks/subgraph/useBadgeModel.tsx
@@ -2,6 +2,7 @@ import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
 import { getFromIPFS } from '@/src/hooks/subgraph/utils'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 import { BadgeModelMetadata } from '@/types/badges/BadgeMetadata'
 import { BackendFileResponse } from '@/types/utils'
 
@@ -12,7 +13,9 @@ import { BackendFileResponse } from '@/types/utils'
  */
 export default function useBadgeModel(id: string) {
   const gql = useSubgraph()
-  return useSWR(id.length ? [`BadgeModel:${id}`, id] : null, async ([, _id]) => {
+  const chainId = useChainId()
+
+  return useSWR(id.length ? [`BadgeModel:${id}`, id, chainId] : null, async ([, _id]) => {
     const response = await gql.badgeModelById({ id: _id })
 
     const badgeModelData = response.badgeModel

--- a/src/hooks/subgraph/useBadgeModelKlerosMetadata.tsx
+++ b/src/hooks/subgraph/useBadgeModelKlerosMetadata.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr'
 import { BadgeModelHooksOptions } from '@/src/hooks/subgraph/types'
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
 import { getFromIPFS } from '@/src/hooks/subgraph/utils'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 import { KlerosListStructure } from '@/src/utils/kleros/generateKlerosListMetaEvidence'
 
 /**
@@ -18,8 +19,10 @@ export function useBadgeModelKlerosMetadata(
   // It's going to do the fetch if it has ID and skip option on false
   const fetchIt = !options?.skip && badgeModelId.length
   const gql = useSubgraph()
+  const chainId = useChainId()
+
   return useSWR(
-    fetchIt ? [`BadgeModelKlerosMetadata:${badgeModelId}`, badgeModelId] : null,
+    fetchIt ? [`BadgeModelKlerosMetadata:${badgeModelId}`, badgeModelId, chainId] : null,
     async ([, _id]) => {
       const badgeModelKleros = await gql.badgeModelKlerosMetadataById({ id: _id })
 
@@ -38,6 +41,7 @@ export function useRegistrationBadgeModelKlerosMetadata(
   badgeModelId: string,
   options?: BadgeModelHooksOptions,
 ) {
+  const chainId = useChainId()
   const badgeModelKlerosMetadata = useBadgeModelKlerosMetadata(badgeModelId, options)
   // It's going to do the fetch if it has ID and skip option on false
   const fetchIt = !options?.skip && badgeModelId.length
@@ -47,6 +51,7 @@ export function useRegistrationBadgeModelKlerosMetadata(
           `RegistrationBadgeModelKlerosMetadata:${badgeModelId}`,
           badgeModelId,
           badgeModelKlerosMetadata.data?.id,
+          chainId,
         ]
       : null,
     async ([,]) => {
@@ -74,6 +79,7 @@ export function useRemovalBadgeModelKlerosMetadata(
   badgeModelId: string,
   options?: BadgeModelHooksOptions,
 ) {
+  const chainId = useChainId()
   const badgeModelKlerosMetadata = useBadgeModelKlerosMetadata(badgeModelId, options)
   // It's going to do the fetch if it has ID and skip option on false
   const fetchIt = !options?.skip && badgeModelId.length
@@ -83,6 +89,7 @@ export function useRemovalBadgeModelKlerosMetadata(
           `RemovalBadgeModelKlerosMetadata:${badgeModelId}`,
           badgeModelId,
           badgeModelKlerosMetadata.data?.id,
+          chainId,
         ]
       : null,
     async ([,]) => {

--- a/src/hooks/subgraph/useCurrentUser.tsx
+++ b/src/hooks/subgraph/useCurrentUser.tsx
@@ -1,13 +1,16 @@
 import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 import { User } from '@/types/generated/subgraph'
 
 export const useCurrentUser = () => {
   const { address } = useWeb3Connection()
   const gql = useSubgraph()
-  return useSWR(address ? `user:${address}` : null, async (_userAddress: string) => {
+  const chainId = useChainId()
+
+  return useSWR(address ? [`user:${address}`, address, chainId] : null, async () => {
     const userById = await gql.userById({ id: address || '' })
     // We need to return an empty object as an User, if not the result from the subgraph is null and SWR will
     // keep the suspense no matter what, bc its thinks that the promise is not resolved yet

--- a/src/hooks/subgraph/useIsBadgeOwner.tsx
+++ b/src/hooks/subgraph/useIsBadgeOwner.tsx
@@ -1,6 +1,7 @@
 import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 
 /**
  * Hook to determine badge ownership, we utilize the potential Owner Address and the badgeModelId. By querying the SG,
@@ -31,9 +32,11 @@ export function useBadgeOwnershipData(badgeModelId: string, ownerAddress: string
  */
 function useBadgesOwnedByModelId(badgeModelId: string, ownerAddress: string | null) {
   const gql = useSubgraph()
+  const chainId = useChainId()
+
   return useSWR(
     badgeModelId.length && ownerAddress?.length
-      ? [`OwnedBadges:${badgeModelId}:${ownerAddress}`, ownerAddress]
+      ? [`OwnedBadges:${badgeModelId}:${ownerAddress}`, ownerAddress, chainId]
       : null,
     async ([,]) => {
       const badgeResponse = await gql.userBadgeByModelId({

--- a/src/hooks/subgraph/useIsCreator.tsx
+++ b/src/hooks/subgraph/useIsCreator.tsx
@@ -5,9 +5,9 @@ import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 
 export default function useIsCreator(address?: string): SWRResponse<boolean> {
   const gql = useSubgraph()
-  const { address: connectedAddress } = useWeb3Connection()
+  const { address: connectedAddress, appChainId } = useWeb3Connection()
   return useSWR(
-    address || connectedAddress ? `isCreator:${address || connectedAddress}` : null,
+    address || connectedAddress ? [`isCreator:${address || connectedAddress}`, appChainId] : null,
     async () => {
       const userById = await gql.userById({ id: address || connectedAddress || '' })
       return !!userById.user?.isCreator

--- a/src/hooks/subgraph/useProtocolStatistic.tsx
+++ b/src/hooks/subgraph/useProtocolStatistic.tsx
@@ -1,11 +1,12 @@
 import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 
 export const useProtocolStatistic = () => {
   const gql = useSubgraph()
-
-  return useSWR([`protocolStatistic:`], async () => {
+  const chainId = useChainId()
+  return useSWR([`protocolStatistic:`, chainId], async () => {
     const protocolStatisticsData = await gql.protocolStatistics()
 
     return protocolStatisticsData.protocolStatistics[0]

--- a/src/hooks/subgraph/useProtocolStatistic.tsx
+++ b/src/hooks/subgraph/useProtocolStatistic.tsx
@@ -1,13 +1,11 @@
 import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
-import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
 
 export const useProtocolStatistic = () => {
-  const { address } = useWeb3Connection()
   const gql = useSubgraph()
 
-  return useSWR(address ? `protocolStatistic:${address}` : null, async (_: string) => {
+  return useSWR([`protocolStatistic:`], async () => {
     const protocolStatisticsData = await gql.protocolStatistics()
 
     return protocolStatisticsData.protocolStatistics[0]

--- a/src/hooks/subgraph/useSubGraphStatus.tsx
+++ b/src/hooks/subgraph/useSubGraphStatus.tsx
@@ -1,11 +1,12 @@
 import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 
 export default function useSubGraphStatus() {
   const gql = useSubgraph()
-
-  return useSWR(`Status`, async () => {
+  const chainId = useChainId()
+  return useSWR([`Status`, chainId], async () => {
     let subGraphErrors
     try {
       subGraphErrors = await gql.subgraphErrors()

--- a/src/hooks/subgraph/useUserById.tsx
+++ b/src/hooks/subgraph/useUserById.tsx
@@ -1,11 +1,13 @@
 import useSWR from 'swr'
 
 import useSubgraph from '@/src/hooks/subgraph/useSubgraph'
+import useChainId from '@/src/hooks/theBadge/useChainId'
 import { User } from '@/types/generated/subgraph'
 
 export const useUserById = (address: string) => {
   const gql = useSubgraph()
-  return useSWR(address ? `user:${address}` : null, async (_userAddress: string) => {
+  const chainId = useChainId()
+  return useSWR(address ? [`user:${address}`, address, chainId] : null, async () => {
     const userById = await gql.userById({ id: address || '' })
     // We need to return an empty object as a User, if not the result from the subgraph is null and SWR will
     // keep the suspense no matter what, bc its thinks that the promise is not resolved yet

--- a/src/hooks/theBadge/useChainId.tsx
+++ b/src/hooks/theBadge/useChainId.tsx
@@ -1,0 +1,7 @@
+import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
+
+export default function useChainId() {
+  const { appChainId } = useWeb3Connection()
+
+  return appChainId
+}

--- a/src/hooks/theBadge/useIsUserVerified.ts
+++ b/src/hooks/theBadge/useIsUserVerified.ts
@@ -1,12 +1,14 @@
 import useSWR from 'swr'
 
+import { useUserById } from '@/src/hooks/subgraph/useUserById'
 import { useContractInstance } from '@/src/hooks/useContractInstance'
 import { TheBadge__factory } from '@/types/generated/typechain'
 
 export default function useIsUserVerified(userAddress: string, controller: string) {
+  const user = useUserById(userAddress)
   const theBadge = useContractInstance(TheBadge__factory, 'TheBadge')
   return useSWR(
-    [`isUserVerified:${userAddress}-${controller}`, userAddress, controller],
-    ([, userAddress, controller]) => theBadge.isUserVerified(userAddress, controller),
+    user.data?.id ? [`isUserVerified:${userAddress}-${controller}`, userAddress, controller] : null,
+    ([, _userAddress, _controller]) => theBadge.isUserVerified(userAddress, controller),
   )
 }

--- a/src/pagePartials/profile/userInfo/InfoPreview.tsx
+++ b/src/pagePartials/profile/userInfo/InfoPreview.tsx
@@ -5,7 +5,6 @@ import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined'
 import TwitterIcon from '@mui/icons-material/Twitter'
 import { Box, IconButton, Stack, Typography } from '@mui/material'
 import { IconDiscord } from '@thebadge/ui-library'
-import { useTranslation } from 'next-export-i18n'
 
 import TBUserAvatar from '@/src/components/common/TBUserAvatar'
 import { Address } from '@/src/components/helpers/Address'
@@ -20,7 +19,6 @@ type Props = {
   address: string
 }
 export default function InfoPreview({ address }: Props) {
-  const { t } = useTranslation()
   const { address: connectedWalletAddress } = useWeb3Connection()
 
   const isLoggedInUser = connectedWalletAddress === address

--- a/src/providers/web3ConnectionProvider.tsx
+++ b/src/providers/web3ConnectionProvider.tsx
@@ -232,14 +232,6 @@ export default function Web3ConnectionProvider({ children }: Props) {
   }, [t])
 
   useEffect(() => {
-    const connectedChainId = hexToNumber(wallet?.chains[0].id)
-    console.log({ previousChainId: previousChainId.current, connectedChainId })
-    if (previousChainId.current !== connectedChainId) {
-      // TODO DO something to update the query data
-    }
-  }, [router, wallet?.chains])
-
-  useEffect(() => {
     if (connectingWallet && window) {
       setTimeout(() => {
         renameWeb3Auth()
@@ -248,11 +240,14 @@ export default function Web3ConnectionProvider({ children }: Props) {
   }, [connectingWallet, renameWeb3Auth])
 
   useEffect(() => {
-    if (isWalletNetworkSupported && walletChainId) {
-      setAppChainId(walletChainId as SetStateAction<ChainsValues>)
-      previousChainId.current = walletChainId as ChainsValues
+    if (isWalletNetworkSupported && wallet?.chains) {
+      const connectedChainId = wallet?.chains
+        ? hexToNumber(wallet?.chains[0].id)
+        : INITIAL_APP_CHAIN_ID
+      setAppChainId(connectedChainId as ChainsValues)
+      previousChainId.current = connectedChainId as ChainsValues
     }
-  }, [walletChainId, isWalletNetworkSupported])
+  }, [wallet?.chains, isWalletNetworkSupported])
 
   // Save connected wallets to localstorage
   useEffect(() => {

--- a/src/providers/web3ConnectionProvider.tsx
+++ b/src/providers/web3ConnectionProvider.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router'
 import {
   Dispatch,
   ReactNode,
@@ -7,6 +8,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react'
 
@@ -178,11 +180,13 @@ initOnboard()
 
 export default function Web3ConnectionProvider({ children }: Props) {
   const { t } = useTranslation()
+  const router = useRouter()
 
   const [{ connecting: connectingWallet, wallet }, connect, disconnect] = useConnectWallet()
   const [{ chains, connectedChain, settingChain }, setChain] = useSetChain()
   const connectedWallets = useWallets()
 
+  const previousChainId = useRef(INITIAL_APP_CHAIN_ID)
   const [appChainId, setAppChainId] = useState(INITIAL_APP_CHAIN_ID)
   const [address, setAddress] = useState<string | null>(null)
   const [isSocialWallet, setIsSocialWallet] = useState<boolean>(false)
@@ -228,6 +232,14 @@ export default function Web3ConnectionProvider({ children }: Props) {
   }, [t])
 
   useEffect(() => {
+    const connectedChainId = hexToNumber(wallet?.chains[0].id)
+    console.log({ previousChainId: previousChainId.current, connectedChainId })
+    if (previousChainId.current !== connectedChainId) {
+      // TODO DO something to update the query data
+    }
+  }, [router, wallet?.chains])
+
+  useEffect(() => {
     if (connectingWallet && window) {
       setTimeout(() => {
         renameWeb3Auth()
@@ -238,6 +250,7 @@ export default function Web3ConnectionProvider({ children }: Props) {
   useEffect(() => {
     if (isWalletNetworkSupported && walletChainId) {
       setAppChainId(walletChainId as SetStateAction<ChainsValues>)
+      previousChainId.current = walletChainId as ChainsValues
     }
   }, [walletChainId, isWalletNetworkSupported])
 


### PR DESCRIPTION
# Description

Protocols Statistics working without a wallet connected
Change from one network to another is made effective when the user acepts the change on the wallet
Make every GQL query refetch after ChainID changes