### PR TITLE
feat: Social login backend verification

### DIFF
--- a/pages/badge/mint/[modelId].tsx
+++ b/pages/badge/mint/[modelId].tsx
@@ -23,7 +23,8 @@ import { NextPageWithLayout } from '@/types/next'
 import { SupportedRelayMethods } from '@/types/relayedTx'
 
 const MintBadgeType: NextPageWithLayout = () => {
-  const { address, appChainId, isSocialWallet, userSocialInfo, web3Provider } = useWeb3Connection()
+  const { address, appChainId, appPubKey, isSocialWallet, userSocialInfo, web3Provider } =
+    useWeb3Connection()
   const theBadge = useContractInstance(TheBadge__factory, 'TheBadge')
   const { resetTxState, sendRelayTx, sendTx, state } = useTransaction()
   const router = useRouter()
@@ -84,8 +85,7 @@ const MintBadgeType: NextPageWithLayout = () => {
         const klerosBadgeModelControllerDataEncoded = encodeIpfsEvidence(evidenceIPFSHash)
 
         // If social login relay tx
-        // @todo (agustin) add more validations, also on backend, user should be authenticated
-        if (isSocialWallet && address && userSocialInfo) {
+        if (isSocialWallet && address && userSocialInfo && appPubKey) {
           const data = JSON.stringify({
             badgeModelId,
             address,
@@ -113,6 +113,7 @@ const MintBadgeType: NextPageWithLayout = () => {
               address,
               userSocialInfo,
             },
+            appPubKey,
           })
         }
         // If user is not social logged, just send the tx

--- a/src/hooks/useTransaction.tsx
+++ b/src/hooks/useTransaction.tsx
@@ -111,7 +111,7 @@ export default function useTransaction() {
       try {
         notifyWaitingForSignature()
         setTransactionState(TransactionStates.waitingSignature)
-        const { chainId, data, from, method, signature, userAccount } = populatedTx
+        const { appPubKey, chainId, data, from, method, signature, userAccount } = populatedTx
         const { error, message, result } = await sendTxToRelayer({
           data,
           from,
@@ -119,6 +119,7 @@ export default function useTransaction() {
           method,
           signature,
           userAccount,
+          appPubKey,
         })
         if (error || !result) {
           throw new Error(message)

--- a/src/providers/web3ConnectionProvider.tsx
+++ b/src/providers/web3ConnectionProvider.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react'
 
 import { JsonRpcProvider, Web3Provider } from '@ethersproject/providers'
+import { getPublicCompressed } from '@toruslabs/eccrypto'
 import { OnboardAPI, WalletState } from '@web3-onboard/core'
 import injectedModule from '@web3-onboard/injected-wallets'
 import { init, useConnectWallet, useSetChain, useWallets } from '@web3-onboard/react'
@@ -165,6 +166,7 @@ export type Web3Context = {
   web3Provider: Web3Provider | null
   web3AuthInstance: Web3Auth | null
   userSocialInfo: Partial<UserInfo> | undefined
+  appPubKey: string | null
 }
 
 export type Web3Connected = RequiredNonNull<Web3Context>
@@ -192,6 +194,7 @@ export default function Web3ConnectionProvider({ children }: Props) {
   const [isSocialWallet, setIsSocialWallet] = useState<boolean>(false)
   const [web3AuthInstance, setWeb3AuthInstance] = useState<Web3Auth | null>(null)
   const [userSocialInfo, setUserSocialInfo] = useState<Partial<UserInfo> | undefined>(undefined)
+  const [appPubKey, setAppPubKey] = useState<string | null>(null)
 
   const web3Provider = wallet?.provider != null ? new Web3Provider(wallet.provider) : null
 
@@ -289,8 +292,23 @@ export default function Web3ConnectionProvider({ children }: Props) {
       const userInfo = await web3AuthInstance?.getUserInfo()
       setUserSocialInfo(userInfo)
     }
+    // Recovers the web3Auth user's pub key in order to validate the user on the backend
+    const fetchAppPubKey = async () => {
+      if (!web3AuthInstance) {
+        return
+      }
+      // If we support non-emv chains this should be private_key
+      const appScopedPrivKey = (await web3AuthInstance.provider?.request({
+        method: 'eth_private_key',
+      })) as string
+      const appPubKey = getPublicCompressed(
+        Buffer.from(appScopedPrivKey.padStart(64, '0'), 'hex'),
+      ).toString('hex')
+      setAppPubKey(appPubKey)
+    }
     if (web3AuthInstance && isSocialWallet) {
       fetchUserInfo()
+      fetchAppPubKey()
     }
   }, [isSocialWallet, web3AuthInstance])
 
@@ -351,6 +369,7 @@ export default function Web3ConnectionProvider({ children }: Props) {
     web3Provider,
     web3AuthInstance,
     userSocialInfo,
+    appPubKey,
   }
 
   return <Web3ContextConnection.Provider value={value}>{children}</Web3ContextConnection.Provider>

--- a/types/relayedTx.ts
+++ b/types/relayedTx.ts
@@ -16,6 +16,8 @@ export interface RelayedTx {
 
   signature: string
 
+  appPubKey: string
+
   userAccount: {
     userSocialInfo: Partial<UserInfo>
     address: string


### PR DESCRIPTION
# Description

- Sends the app public key to the backend in order to auth the transactions [reference](https://web3auth.io/docs/pnp/features/server-side-verification/social-login-users)