### PR TITLE
feat: Improve error boundary display

### DIFF
--- a/src/components/helpers/GeneralError.tsx
+++ b/src/components/helpers/GeneralError.tsx
@@ -7,7 +7,9 @@ export const GeneralError = ({ error, resetErrorBoundary }: FallbackProps) => {
   return (
     <div role="alert">
       <Typography>Oh no</Typography>
-      <pre>{error.message}</pre>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>
+        {error.message ? error.message : JSON.stringify(error)}
+      </pre>
       <button onClick={resetErrorBoundary}>Try again</button>
     </div>
   )
@@ -19,7 +21,9 @@ export const GeneralPageError = ({ error, resetErrorBoundary }: FallbackProps) =
   return (
     <div role="alert">
       <Typography>Oh no! 🙈</Typography>
-      <pre>{error.message}</pre>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>
+        {error.message ? error.message : JSON.stringify(error)}
+      </pre>
       <Stack alignItems="flex-start" gap={1}>
         <Button color="green" onClick={resetErrorBoundary} sx={{ textTransform: 'none', p: 0 }}>
           Try again

--- a/src/components/helpers/SafeSuspense.tsx
+++ b/src/components/helpers/SafeSuspense.tsx
@@ -38,6 +38,7 @@ export default function SafeSuspense({
         <GeneralError error={error} resetErrorBoundary={resetErrorBoundary} />
       )}
       onError={(error, info) => isDev && console.error(error, info)}
+      resetKeys={[children]}
     >
       <Suspense fallback={fallback}>{children}</Suspense>
     </ErrorBoundary>
@@ -59,6 +60,7 @@ export function withPageGenericSuspense<TProps>(
         <GeneralPageError error={error} resetErrorBoundary={resetErrorBoundary} />
       )}
       onError={(error, info) => isDev && console.error(error, info)}
+      resetKeys={[Page]}
     >
       <Suspense
         fallback={


### PR DESCRIPTION
# Description

Improve text to dont have a scrollbar, also stringify the error in case that doesn't have a message. Reset error boundary when children change
