### PR TITLE
fix: Statistics be refreshed on each mount and prevent wrong values

### DIFF
--- a/i18n/translations.en.json
+++ b/i18n/translations.en.json
@@ -201,6 +201,7 @@
         "amountChallengesReceived": "Challenges received",
         "minted": "Badges minted",
         "withoutLost": "without received challenges",
+        "neverChallenged": "You've never received a challenge",
         "rankingPosition": "Position in curators ranking"
       }
     }

--- a/src/hooks/subgraph/useCreatorStatistics.tsx
+++ b/src/hooks/subgraph/useCreatorStatistics.tsx
@@ -7,7 +7,11 @@ export default function useCreatorStatistics() {
   const { address, appChainId } = useWeb3Connection()
 
   const gql = useSubgraph()
-  return useSWR(address ? [`creatorStatistics`, address, appChainId] : null, ([, _address]) => {
-    return gql.creatorStatistics({ address: _address })
-  })
+  return useSWR(
+    address ? [`creatorStatistics`, address, appChainId] : null,
+    ([, _address]) => {
+      return gql.creatorStatistics({ address: _address })
+    },
+    { revalidateOnMount: true },
+  )
 }

--- a/src/hooks/subgraph/useCuratorStatistics.tsx
+++ b/src/hooks/subgraph/useCuratorStatistics.tsx
@@ -7,7 +7,11 @@ export default function useCuratorStatistics() {
   const { address, appChainId } = useWeb3Connection()
 
   const gql = useSubgraph()
-  return useSWR(address ? [`curatorStatistics`, address, appChainId] : null, ([, _address]) => {
-    return gql.curatorStatistics({ address: _address })
-  })
+  return useSWR(
+    address ? [`curatorStatistics`, address, appChainId] : null,
+    ([, _address]) => {
+      return gql.curatorStatistics({ address: _address })
+    },
+    { revalidateOnMount: true },
+  )
 }

--- a/src/hooks/subgraph/useProtocolStatistic.tsx
+++ b/src/hooks/subgraph/useProtocolStatistic.tsx
@@ -6,9 +6,13 @@ import useChainId from '@/src/hooks/theBadge/useChainId'
 export const useProtocolStatistic = () => {
   const gql = useSubgraph()
   const chainId = useChainId()
-  return useSWR([`protocolStatistic:`, chainId], async () => {
-    const protocolStatisticsData = await gql.protocolStatistics()
+  return useSWR(
+    [`protocolStatistic:`, chainId],
+    async () => {
+      const protocolStatisticsData = await gql.protocolStatistics()
 
-    return protocolStatisticsData.protocolStatistics[0]
-  })
+      return protocolStatisticsData.protocolStatistics[0]
+    },
+    { revalidateOnMount: true },
+  )
 }

--- a/src/hooks/subgraph/useUserStatistics.tsx
+++ b/src/hooks/subgraph/useUserStatistics.tsx
@@ -7,7 +7,11 @@ export default function useUserStatistics() {
   const { address, appChainId } = useWeb3Connection()
 
   const gql = useSubgraph()
-  return useSWR(address ? [`userStatistics`, address, appChainId] : null, ([, _address]) => {
-    return gql.userStatistics({ address: _address })
-  })
+  return useSWR(
+    address ? [`userStatistics`, address, appChainId] : null,
+    ([, _address]) => {
+      return gql.userStatistics({ address: _address })
+    },
+    { revalidateOnMount: true },
+  )
 }

--- a/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
+++ b/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
@@ -83,24 +83,28 @@ export default function UserStatisticContent({
               <BalanceOutlinedIcon
                 sx={{ color: theme.palette.text.primary, position: 'absolute', top: 8, left: 8 }}
               />
-              {userStatistic?.challengesReceivedAmount > 0 &&
-              userStatistic?.timeOfLastChallengeReceived ? (
-                <>
-                  <Typography sx={{ fontSize: '48px !important', fontWeight: 900 }}>
-                    {timeAgoFrom(userStatistic?.timeOfLastChallengeReceived || 0)}
-                  </Typography>
-                  <Typography sx={{ textAlign: 'center', color: 'text.primary' }}>
-                    {t('profile.statistics.user.withoutLost')}
-                  </Typography>
-                </>
-              ) : (
-                <>
-                  <Typography sx={{ fontSize: '48px !important', fontWeight: 900 }}>0</Typography>
-                  <Typography sx={{ textAlign: 'center', color: 'text.primary' }}>
-                    {t('profile.statistics.user.amountChallengesReceived')}
-                  </Typography>
-                </>
-              )}
+              <Typography sx={{ fontSize: '48px !important', fontWeight: 900 }}>
+                {timeAgoFrom(userStatistic?.timeOfLastChallengeReceived || 0)}
+              </Typography>
+              <Typography sx={{ textAlign: 'center', color: 'text.primary' }}>
+                {t('profile.statistics.user.withoutLost')}
+              </Typography>
+            </StatisticSquare>
+          </Stack>
+        )}
+
+        {statisticVisibility[UserStatistic.amountWithoutChallenge] && (
+          <Stack flex="1" minWidth="160px">
+            <StatisticSquare color={theme.palette.text.primary}>
+              <BalanceOutlinedIcon
+                sx={{ color: theme.palette.text.primary, position: 'absolute', top: 8, left: 8 }}
+              />
+              <Typography sx={{ fontSize: '48px !important', fontWeight: 900 }}>
+                {userStatistic?.challengesReceivedAmount || 0}
+              </Typography>
+              <Typography sx={{ textAlign: 'center', color: 'text.primary' }}>
+                {t('profile.statistics.user.amountChallengesReceived')}
+              </Typography>
             </StatisticSquare>
           </Stack>
         )}

--- a/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
+++ b/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
@@ -83,12 +83,20 @@ export default function UserStatisticContent({
               <BalanceOutlinedIcon
                 sx={{ color: theme.palette.text.primary, position: 'absolute', top: 8, left: 8 }}
               />
-              <Typography sx={{ fontSize: '48px !important', fontWeight: 900 }}>
-                {timeAgoFrom(userStatistic?.timeOfLastChallengeReceived || 0)}
-              </Typography>
-              <Typography sx={{ textAlign: 'center', color: 'text.primary' }}>
-                {t('profile.statistics.user.withoutLost')}
-              </Typography>
+              {userStatistic?.timeOfLastChallengeReceived &&
+              userStatistic?.timeOfLastChallengeReceived !== '0' ? (
+                <>
+                  {timeAgoFrom(userStatistic?.timeOfLastChallengeReceived || 0)}
+                  <Typography sx={{ fontSize: '48px !important', fontWeight: 900 }}></Typography>
+                  <Typography sx={{ textAlign: 'center', color: 'text.primary' }}>
+                    {t('profile.statistics.user.withoutLost')}
+                  </Typography>
+                </>
+              ) : (
+                <Typography sx={{ textAlign: 'center', color: 'text.primary' }}>
+                  {t('profile.statistics.user.neverChallenged')}
+                </Typography>
+              )}
             </StatisticSquare>
           </Stack>
         )}

--- a/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
+++ b/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
@@ -9,9 +9,8 @@ import { Box, Stack, Table, TableBody, Typography, useTheme } from '@mui/materia
 import { useTranslation } from 'next-export-i18n'
 
 import { StatisticSquare, StatisticsContainer } from '../addons/styled'
-import { getNetworkConfig } from '@/src/config/web3'
 import { StatisticVisibility } from '@/src/hooks/nextjs/useStatisticsVisibility'
-import useUserStatistics from '@/src/hooks/subgraph/useUserrStatistics'
+import useUserStatistics from '@/src/hooks/subgraph/useUserStatistics'
 import StatisticRow from '@/src/pagePartials/profile/statistics/addons/StatisticRow'
 import { UserStatistic } from '@/src/pagePartials/profile/statistics/user/UserStatistics'
 import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
@@ -24,7 +23,6 @@ export default function UserStatisticContent({
   const { t } = useTranslation()
   const theme = useTheme()
   const { appChainId } = useWeb3Connection()
-  const networkConfig = getNetworkConfig(appChainId)
 
   const statistics = useUserStatistics()
 

--- a/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
+++ b/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
@@ -14,6 +14,7 @@ import useUserStatistics from '@/src/hooks/subgraph/useUserStatistics'
 import StatisticRow from '@/src/pagePartials/profile/statistics/addons/StatisticRow'
 import { UserStatistic } from '@/src/pagePartials/profile/statistics/user/UserStatistics'
 import { timeAgoFrom } from '@/src/utils/dateUtils'
+
 export default function UserStatisticContent({
   statisticVisibility,
 }: {
@@ -21,13 +22,10 @@ export default function UserStatisticContent({
 }) {
   const { t } = useTranslation()
   const theme = useTheme()
-  const { appChainId } = useWeb3Connection()
 
   const statistics = useUserStatistics()
 
   const userStatistic = statistics.data?.userStatistic
-
-  console.log('challengesReceivedAmount', userStatistic?.challengesReceivedAmount)
 
   return (
     <StatisticsContainer>

--- a/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
+++ b/src/pagePartials/profile/statistics/user/UserStatisticContent.tsx
@@ -93,7 +93,7 @@ export default function UserStatisticContent({
           </Stack>
         )}
 
-        {statisticVisibility[UserStatistic.amountWithoutChallenge] && (
+        {statisticVisibility[UserStatistic.challengesReceivedAmount] && (
           <Stack flex="1" minWidth="160px">
             <StatisticSquare color={theme.palette.text.primary}>
               <BalanceOutlinedIcon

--- a/src/pagePartials/profile/statistics/user/UserStatistics.tsx
+++ b/src/pagePartials/profile/statistics/user/UserStatistics.tsx
@@ -16,6 +16,7 @@ export enum UserStatistic {
   amountMinted = 'Badges minted',
   amountWithoutChallenge = 'Days without challenges',
   amountChallengeLost = 'Challenges lost',
+  challengesReceivedAmount = 'Challenges received',
 }
 
 export const UserStatisticDefaultVisibility = {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -54,12 +54,12 @@ export function secondsToMinutes(periodDuration: number) {
  * @param timestamp
  */
 export const timeAgoFrom = (timestamp?: string | number) => {
-  if (!timestamp) {
-    return ''
+  if (!timestamp || !Number(timestamp)) {
+    return '-'
   }
   const format = dayjs.unix(Number(timestamp)).fromNow(true)
   if (format !== null) return format
-  return ''
+  return '-'
 }
 
 /**
@@ -67,12 +67,12 @@ export const timeAgoFrom = (timestamp?: string | number) => {
  * @param timestamp
  */
 export const timeLeftTo = (timestamp?: string | number) => {
-  if (!timestamp) {
-    return ''
+  if (!timestamp || !Number(timestamp)) {
+    return '-'
   }
   const format = dayjs().to(dayjs.unix(Number(timestamp)), true)
   if (format !== null) return format
-  return ''
+  return '-'
 }
 
 /**
@@ -80,32 +80,33 @@ export const timeLeftTo = (timestamp?: string | number) => {
  * @param timestamp
  */
 export const timeLeftToShort = (timestamp?: string | number) => {
-  if (!timestamp) {
-    return ''
+  if (!timestamp || !Number(timestamp)) {
+    return '-'
   }
   const format = dayjs().to(dayjs.unix(Number(timestamp)), true)
   if (format !== null) return format
-  return ''
+  return '-'
 }
 
 /**
- * By default expect Unix Timestamp (seconds)
+ * By default, expect Unix Timestamp (seconds)
  * @param timestamp
+ * @param dateFormat 'MMM DD, YYYY [at] hh:mm A'
  */
 export const formatTimestamp = (
   timestamp?: string | number,
   dateFormat = 'MMM DD, YYYY [at] hh:mm A',
 ) => {
-  if (!timestamp) {
-    return ''
+  if (!timestamp || !Number(timestamp)) {
+    return '-'
   }
   const format = dayjs.unix(Number(timestamp)).format(dateFormat)
   if (format !== null) return format
-  return ''
+  return '-'
 }
 
 export const isBeforeToday = (timestamp?: string | number) => {
-  if (!timestamp) {
+  if (!timestamp || !Number(timestamp)) {
     return false
   }
   // Check if now is after the give timestamp


### PR DESCRIPTION
# Description

Fix dateUtils to return "-" and validate zero as strings
Update queries to be revalidated on mount

Validating the 0 as a string, we prevent the following behavior

Before:
![image](https://github.com/thebadge/thebadge-dapp/assets/21246763/430d2b12-19fe-48a4-824b-279aa0463128)

After:
![image](https://github.com/thebadge/thebadge-dapp/assets/21246763/6b1c1696-9d3c-498d-87b0-63264f478b34)
