### PR TITLE
feat: Implement send email retry button

### DIFF
--- a/i18n/translations.en.json
+++ b/i18n/translations.en.json
@@ -314,6 +314,7 @@
     "thirdPartyBadgeUnclaimedText": "The badge has not been claimed, an email has been sent to the user.",
     "claimButtonDisabledTooltip": "You cannot claim this badge yet.",
     "renewButton": "Renew",
+    "resendEmailButton": "Resend email",
     "model": {
       "create": {
         "howItWorks": "How it works",

--- a/src/hooks/theBadge/useSendClaimEmail.ts
+++ b/src/hooks/theBadge/useSendClaimEmail.ts
@@ -1,0 +1,55 @@
+import { useSignMessage } from 'wagmi'
+
+import { notify } from '@/src/components/toast/Toast'
+import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
+import { sendEmailClaim } from '@/src/utils/relayTx'
+import { EmailClaimTx } from '@/types/relayedTx'
+import { ToastStates } from '@/types/toast'
+import { BackendResponse } from '@/types/utils'
+
+type Response = Promise<BackendResponse<{ txHash: string | null }>>
+
+export default function useSendClaimEmail(): {
+  submitSendClaimEmail: (props: EmailClaimTx) => Response
+} {
+  const { signMessageAsync } = useSignMessage()
+  const { address } = useWeb3Connection()
+
+  const submitSendClaimEmail = async (props: EmailClaimTx): Response => {
+    const { badgeModelId, emailClaimer, mintTxHash, networkId } = props
+    const signedMessage = `I accept the terms & conditions and I verify to be the owner of the address: ${address}`
+    const signature = await signMessageAsync({
+      message: signedMessage,
+    })
+
+    const result = await sendEmailClaim({
+      networkId,
+      mintTxHash,
+      badgeModelId,
+      emailClaimer,
+      signature,
+      signedMessage,
+      ownerAddress: address as string,
+    })
+
+    if (result.error) {
+      notify({
+        id: mintTxHash,
+        type: ToastStates.infoFailed,
+        message: result.message,
+        position: 'bottom-right',
+      })
+    } else {
+      notify({
+        id: mintTxHash,
+        type: ToastStates.info,
+        message: result.message,
+        position: 'bottom-right',
+      })
+    }
+
+    return result
+  }
+
+  return { submitSendClaimEmail }
+}

--- a/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
+++ b/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
@@ -18,7 +18,7 @@ export default function ThirdPartyBadgeEvidenceInfoPreview({ badge }: { badge: B
   const { t } = useTranslation()
   const { data: isClaimable } = useIsClaimable(badge.id)
   const { appChainId, isAppConnected } = useWeb3Connection()
-  const { submitSendClaimEmail } = useSendClaimEmail()
+  const submitSendClaimEmail = useSendClaimEmail()
   const [disableButtons, setDisableButtons] = useState(false)
 
   const sendClaimEmail = async () => {

--- a/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
+++ b/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
@@ -1,18 +1,62 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 import { Box, Stack, Typography } from '@mui/material'
-import { colors } from '@thebadge/ui-library'
+import { ButtonV2, colors } from '@thebadge/ui-library'
 import { useTranslation } from 'next-export-i18n'
 
+import { notify } from '@/src/components/toast/Toast'
 import useIsClaimable from '@/src/hooks/subgraph/useIsClaimable'
 import BadgeIdDisplay from '@/src/pagePartials/badge/explorer/addons/BadgeIdDisplay'
 import BadgeRequesterPreview from '@/src/pagePartials/badge/explorer/addons/BadgeRequesterPreview'
+import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
+import { sendEmailClaim } from '@/src/utils/relayTx'
 import { Badge } from '@/types/generated/subgraph'
+import { ToastStates } from '@/types/toast'
 import { WCAddress } from '@/types/utils'
 
 export default function ThirdPartyBadgeEvidenceInfoPreview({ badge }: { badge: Badge }) {
   const { t } = useTranslation()
   const { data: isClaimable } = useIsClaimable(badge.id)
+  const { appChainId, isAppConnected } = useWeb3Connection()
+  const [disableButtons, setDisableButtons] = useState(false)
+
+  const sendClaimEmail = async () => {
+    try {
+      setDisableButtons(true)
+      const result = await sendEmailClaim({
+        networkId: appChainId.toString(),
+        mintTxHash: badge.createdTxHash,
+        badgeModelId: Number(badge.badgeModel.id),
+      })
+
+      if (result.error) {
+        notify({
+          id: badge.createdTxHash,
+          type: ToastStates.infoFailed,
+          message: result.message,
+          position: 'bottom-right',
+        })
+        return
+      }
+
+      notify({
+        id: badge.createdTxHash,
+        type: ToastStates.info,
+        message: result.message,
+        position: 'bottom-right',
+      })
+    } catch (error) {
+      console.warn('Sending email errored ', error)
+      notify({
+        id: badge.createdTxHash,
+        type: ToastStates.infoFailed,
+        message: 'Re-sending email failed!',
+        position: 'bottom-right',
+      })
+    } finally {
+      setDisableButtons(false)
+    }
+  }
 
   return (
     <Stack gap={4} p={1}>
@@ -30,10 +74,21 @@ export default function ThirdPartyBadgeEvidenceInfoPreview({ badge }: { badge: B
       </Box>
 
       {/* Badge Receiver Address */}
-      {isClaimable ? (
-        <Typography color={colors.redError} mb={4}>
-          {t('badge.thirdPartyBadgeUnclaimedText')}
-        </Typography>
+      {isClaimable && isAppConnected ? (
+        <Stack alignContent="center" display="flex" flex={1} justifyContent="space-between">
+          <Typography color={colors.redError} mb={4}>
+            {t('badge.thirdPartyBadgeUnclaimedText')}
+          </Typography>
+          <ButtonV2
+            backgroundColor={colors.green}
+            disabled={disableButtons}
+            onClick={() => sendClaimEmail()}
+            sx={{ ml: 'auto' }}
+            variant="contained"
+          >
+            {t('badge.resendEmailButton')}
+          </ButtonV2>
+        </Stack>
       ) : (
         <BadgeRequesterPreview ownerAddress={badge.account.id as WCAddress} />
       )}

--- a/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
+++ b/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
@@ -47,7 +47,7 @@ export default function ThirdPartyBadgeEvidenceInfoPreview({ badge }: { badge: B
   return (
     <Stack gap={4} p={1}>
       <Box alignContent="center" display="flex" flex={1} justifyContent="space-between">
-        <BadgeIdDisplay id={badge?.id} mintTxHash={badge.createdTxHash} />
+        <BadgeIdDisplay id={badge?.id} isBadgeModel={false} mintTxHash={badge.createdTxHash} />
         {isClaimable ? (
           <Typography color={colors.redError} mb={4} textTransform="uppercase">
             {t('badge.unclaimed')}

--- a/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
+++ b/src/pagePartials/badge/explorer/ThirdPartyBadgeEvidenceInfoPreview.tsx
@@ -6,10 +6,10 @@ import { useTranslation } from 'next-export-i18n'
 
 import { notify } from '@/src/components/toast/Toast'
 import useIsClaimable from '@/src/hooks/subgraph/useIsClaimable'
+import useSendClaimEmail from '@/src/hooks/theBadge/useSendClaimEmail'
 import BadgeIdDisplay from '@/src/pagePartials/badge/explorer/addons/BadgeIdDisplay'
 import BadgeRequesterPreview from '@/src/pagePartials/badge/explorer/addons/BadgeRequesterPreview'
 import { useWeb3Connection } from '@/src/providers/web3ConnectionProvider'
-import { sendEmailClaim } from '@/src/utils/relayTx'
 import { Badge } from '@/types/generated/subgraph'
 import { ToastStates } from '@/types/toast'
 import { WCAddress } from '@/types/utils'
@@ -18,33 +18,19 @@ export default function ThirdPartyBadgeEvidenceInfoPreview({ badge }: { badge: B
   const { t } = useTranslation()
   const { data: isClaimable } = useIsClaimable(badge.id)
   const { appChainId, isAppConnected } = useWeb3Connection()
+  const { submitSendClaimEmail } = useSendClaimEmail()
   const [disableButtons, setDisableButtons] = useState(false)
 
   const sendClaimEmail = async () => {
     try {
       setDisableButtons(true)
-      const result = await sendEmailClaim({
+      const result = await submitSendClaimEmail({
         networkId: appChainId.toString(),
         mintTxHash: badge.createdTxHash,
         badgeModelId: Number(badge.badgeModel.id),
       })
 
-      if (result.error) {
-        notify({
-          id: badge.createdTxHash,
-          type: ToastStates.infoFailed,
-          message: result.message,
-          position: 'bottom-right',
-        })
-        return
-      }
-
-      notify({
-        id: badge.createdTxHash,
-        type: ToastStates.info,
-        message: result.message,
-        position: 'bottom-right',
-      })
+      console.log(result)
     } catch (error) {
       console.warn('Sending email errored ', error)
       notify({

--- a/src/pagePartials/badge/mint/MintThirdPartyBadgeModel.tsx
+++ b/src/pagePartials/badge/mint/MintThirdPartyBadgeModel.tsx
@@ -133,13 +133,12 @@ const MintThirdPartyBadgeModel: NextPageWithLayout = () => {
         )
         const { transactionHash } = await transactionReceipt.wait()
         if (preferMintMethod === 'email') {
-          const result = await submitSendClaimEmail({
+          await submitSendClaimEmail({
             networkId: appChainId.toString(),
             mintTxHash: transactionHash,
             badgeModelId: Number(badgeModelId),
             emailClaimer: destination,
           })
-          console.log(result)
         }
         return transactionReceipt
       })

--- a/src/pagePartials/badge/mint/MintThirdPartyBadgeModel.tsx
+++ b/src/pagePartials/badge/mint/MintThirdPartyBadgeModel.tsx
@@ -36,7 +36,7 @@ const MintThirdPartyBadgeModel: NextPageWithLayout = () => {
   const { resetTxState, sendTx, state } = useTransaction()
   const router = useRouter()
   const { badgeModelId, contract } = useModelIdParam()
-  const { submitSendClaimEmail } = useSendClaimEmail()
+  const submitSendClaimEmail = useSendClaimEmail()
 
   if (!badgeModelId) {
     throw `No modelId provided us URL query param`

--- a/src/pagePartials/badge/mint/MintThirdPartyBadgeModel.tsx
+++ b/src/pagePartials/badge/mint/MintThirdPartyBadgeModel.tsx
@@ -3,12 +3,12 @@ import * as React from 'react'
 import { useEffect } from 'react'
 
 import { withPageGenericSuspense } from '@/src/components/helpers/SafeSuspense'
-import { notify } from '@/src/components/toast/Toast'
 import { ZERO_ADDRESS } from '@/src/constants/bigNumber'
 import useModelIdParam from '@/src/hooks/nextjs/useModelIdParam'
 import useBadgeModel from '@/src/hooks/subgraph/useBadgeModel'
 import { useBadgeModelThirdPartyMetadata } from '@/src/hooks/subgraph/useBadgeModelThirdPartyMetadata'
 import useMintValue from '@/src/hooks/theBadge/useMintValue'
+import useSendClaimEmail from '@/src/hooks/theBadge/useSendClaimEmail'
 import useTBContract from '@/src/hooks/theBadge/useTBContract'
 import useTBStore from '@/src/hooks/theBadge/useTBStore'
 import useTransaction, { TransactionStates } from '@/src/hooks/useTransaction'
@@ -23,10 +23,9 @@ import {
 } from '@/src/utils/badges/mintHelpers'
 const { useWeb3Connection } = await import('@/src/providers/web3ConnectionProvider')
 import { generateProfileUrl } from '@/src/utils/navigation/generateUrl'
-import { getEncryptedValues, sendEmailClaim } from '@/src/utils/relayTx'
+import { getEncryptedValues } from '@/src/utils/relayTx'
 import { BadgeModelMetadata } from '@/types/badges/BadgeMetadata'
 import { NextPageWithLayout } from '@/types/next'
-import { ToastStates } from '@/types/toast'
 
 const MintThirdPartyBadgeModel: NextPageWithLayout = () => {
   const { appChainId, getSocialCompressedPubKey, isSocialWallet, web3Auth } = useWeb3Connection()
@@ -35,6 +34,7 @@ const MintThirdPartyBadgeModel: NextPageWithLayout = () => {
   const { resetTxState, sendTx, state } = useTransaction()
   const router = useRouter()
   const { badgeModelId, contract } = useModelIdParam()
+  const { submitSendClaimEmail } = useSendClaimEmail()
 
   if (!badgeModelId) {
     throw `No modelId provided us URL query param`
@@ -135,18 +135,13 @@ const MintThirdPartyBadgeModel: NextPageWithLayout = () => {
 
         // TODO This should be done async, notifying the relayer before sending the tx, or asking the relayer to send the tx
         if (preferMintMethod === 'email') {
-          await sendEmailClaim({
+          const result = await submitSendClaimEmail({
             networkId: appChainId.toString(),
             mintTxHash: transactionHash,
             badgeModelId: Number(badgeModelId),
             emailClaimer: destination,
           })
-          notify({
-            id: transactionHash,
-            type: ToastStates.info,
-            message: `Email successfully sent to: ${destination}`,
-            position: 'top-right',
-          })
+          console.log(result)
         }
       }
       cleanMintFormValues(badgeModelId)

--- a/src/utils/relayTx.ts
+++ b/src/utils/relayTx.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 import { ZERO_ADDRESS } from '@/src/constants/bigNumber'
-import { EmailClaimTx, RelayedTx, RelayedTxResult } from '@/types/relayedTx'
+import { EmailClaimTxSigned, RelayedTx, RelayedTxResult } from '@/types/relayedTx'
 import { BackendResponse } from '@/types/utils'
 
 export const sendTxToRelayer = async (
@@ -16,7 +16,7 @@ export const sendTxToRelayer = async (
 
 // TODO This should be removed and this method should be directly inside the relayer, we just need to ask the relayer to relay the  tx
 export const sendEmailClaim = async (
-  param: EmailClaimTx,
+  param: EmailClaimTxSigned,
 ): Promise<BackendResponse<{ txHash: string | null }>> => {
   const res = await axios.post<BackendResponse<{ txHash: string | null }>>(
     `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/thirdPartyController/sendMintMail`,

--- a/types/relayedTx.ts
+++ b/types/relayedTx.ts
@@ -31,7 +31,7 @@ export interface EmailClaimTx {
 
   badgeModelId: number
 
-  emailClaimer: string
+  emailClaimer?: string
 }
 
 export interface RelayedTxResult {

--- a/types/relayedTx.ts
+++ b/types/relayedTx.ts
@@ -34,6 +34,14 @@ export interface EmailClaimTx {
   emailClaimer?: string
 }
 
+export type EmailClaimTxSigned = EmailClaimTx & {
+  signature: string
+
+  signedMessage: string
+
+  ownerAddress: string
+}
+
 export interface RelayedTxResult {
   txHash: string | null
   valid: boolean


### PR DESCRIPTION
# Description

- Adds the button to send an email again to the user for claiming the thirdParty badge

![image](https://github.com/thebadge/thebadge-dapp/assets/21086218/8871d320-7893-48b6-a958-575f719f699d)
