### PR TITLE
chore: Use previewUrl with sharableUrl

### DIFF
--- a/src/pagePartials/badge/claim/steps/StepsClaimThirdPartyPreview.tsx
+++ b/src/pagePartials/badge/claim/steps/StepsClaimThirdPartyPreview.tsx
@@ -18,7 +18,7 @@ export const StepClaimThirdPartyPreview = () => {
   const { setValue } = useFormContext<ClaimThirdPartyBadgeSchemaType>()
   const { badgeId, contract, modelId } = useClaimParams()
   const { address, chainId } = parsePrefixedAddress(contract)
-  const { badgePreviewUrl } = useBadgePreviewUrl(badgeId, address, chainId)
+  const { shortPreviewURl } = useBadgePreviewUrl(badgeId, address, chainId)
   const requiredBadgeDataMetadata = useBadgeThirdPartyRequiredData(`${badgeId}` || '')
 
   const values = reCreateThirdPartyValuesObject(
@@ -31,7 +31,7 @@ export const StepClaimThirdPartyPreview = () => {
       <SafeSuspense>
         <BadgeThirdPartyPreviewGenerator
           additionalData={{ ...values }}
-          badgeUrl={badgePreviewUrl}
+          badgeUrl={shortPreviewURl}
           modelId={modelId}
           setValue={setValue}
           title={t('badge.model.claim.thirdParty.preview.title')}

--- a/src/pagePartials/badge/claim/steps/StepsClaimThirdPartySucceed.tsx
+++ b/src/pagePartials/badge/claim/steps/StepsClaimThirdPartySucceed.tsx
@@ -34,7 +34,7 @@ export default function StepsClaimThirdPartySucceed({
   const { data } = useBadgeModel(modelId)
 
   const requiredBadgeDataMetadata = useBadgeThirdPartyRequiredData(`${badgeId}` || '')
-  const { badgePreviewUrl, shortPreviewURl } = useBadgePreviewUrl(badgeId, contract)
+  const { shortPreviewShareableUrl, shortPreviewURl } = useBadgePreviewUrl(badgeId, contract)
 
   const values = reCreateThirdPartyValuesObject(
     requiredBadgeDataMetadata.data?.requirementsDataValues || {},
@@ -62,7 +62,7 @@ export default function StepsClaimThirdPartySucceed({
       </Typography>
       <ThirdPartyPreview
         additionalData={{ ...values }}
-        badgeUrl={badgePreviewUrl}
+        badgeUrl={shortPreviewURl}
         modelId={modelId}
       />
       <Divider />
@@ -79,7 +79,7 @@ export default function StepsClaimThirdPartySucceed({
       <Stack>
         <TwitterShareButton
           related={['@thebadgexyz']}
-          url={generateTwitterText(badgeModelName, shortPreviewURl)}
+          url={generateTwitterText(badgeModelName, shortPreviewShareableUrl)}
         >
           <XIcon round size={32} />
         </TwitterShareButton>

--- a/src/pagePartials/badge/mint/steps/preview/MintSucceed.tsx
+++ b/src/pagePartials/badge/mint/steps/preview/MintSucceed.tsx
@@ -34,7 +34,7 @@ export default function MintSucceed() {
   // TODO Fetch the new badgeId minted from the graph and use this to generate the badgeUrl
   const estimatedBadgeIdForPreview = estimatedBadgeId ? estimatedBadgeId.sub(1).toString() : '0'
 
-  const { badgePreviewUrl } = useBadgePreviewUrl(
+  const { shortPreviewURl } = useBadgePreviewUrl(
     estimatedBadgeIdForPreview,
     badgeModelData.data.badgeModel.contractAddress,
     appChainId,
@@ -46,7 +46,7 @@ export default function MintSucceed() {
         animationEffects={['wobble', 'grow', 'glare']}
         animationOnHover
         badgeBackgroundUrl={getBackgroundBadgeUrl(backgroundType?.value, modelBackgrounds)}
-        badgeUrl={badgePreviewUrl}
+        badgeUrl={shortPreviewURl}
         category={badgeModelMetadata?.name}
         description={badgeModelMetadata?.description}
         imageUrl={badgeLogoImage?.s3Url}

--- a/src/pagePartials/badge/mint/steps/preview/SubmitPreview.tsx
+++ b/src/pagePartials/badge/mint/steps/preview/SubmitPreview.tsx
@@ -70,7 +70,7 @@ export default function SubmitPreview({
   }
 
   const estimatedBadgeIdForPreview = estimatedBadgeId ? estimatedBadgeId.toString() : '0'
-  const { badgePreviewUrl } = useBadgePreviewUrl(
+  const { shortPreviewURl } = useBadgePreviewUrl(
     estimatedBadgeIdForPreview,
     badgeModelData.data.badgeModel.contractAddress,
     appChainId,
@@ -88,7 +88,7 @@ export default function SubmitPreview({
           animationEffects={['wobble', 'grow', 'glare']}
           animationOnHover
           badgeBackgroundUrl={getBackgroundBadgeUrl(backgroundType?.value, modelBackgrounds)}
-          badgeUrl={badgePreviewUrl}
+          badgeUrl={shortPreviewURl}
           category={badgeModelMetadata?.name}
           description={badgeModelMetadata?.description}
           imageUrl={badgeLogoImage?.s3Url}

--- a/src/pagePartials/badge/mint/steps/preview/thirdParty/SubmitPreviewThirdParty.tsx
+++ b/src/pagePartials/badge/mint/steps/preview/thirdParty/SubmitPreviewThirdParty.tsx
@@ -38,7 +38,7 @@ export default function SubmitPreviewThirdParty() {
   }
 
   const estimatedBadgeIdForPreview = estimatedBadgeId ? estimatedBadgeId.toString() : '0'
-  const { badgePreviewUrl } = useBadgePreviewUrl(
+  const { shortPreviewURl } = useBadgePreviewUrl(
     estimatedBadgeIdForPreview,
     badgeModelData.data.badgeModel.contractAddress,
     appChainId,
@@ -52,7 +52,7 @@ export default function SubmitPreviewThirdParty() {
             additionalData={{
               ...values,
             }}
-            badgeUrl={badgePreviewUrl}
+            badgeUrl={shortPreviewURl}
             modelId={badgeModelId}
             setValue={setValue}
             title={t('badge.model.mint.previewTitle', {

--- a/src/pagePartials/badge/preview/BadgeOwnedPreview.tsx
+++ b/src/pagePartials/badge/preview/BadgeOwnedPreview.tsx
@@ -190,7 +190,7 @@ export default function BadgeOwnedPreview() {
                 <IconButton
                   aria-label="Share badge preview"
                   component="label"
-                  onClick={() => handleShare()}
+                  onClick={() => handleShare(shortPreviewShareableUrl)}
                 >
                   <ShareOutlinedIcon />
                 </IconButton>

--- a/src/pagePartials/badge/preview/BadgeOwnedPreview.tsx
+++ b/src/pagePartials/badge/preview/BadgeOwnedPreview.tsx
@@ -80,10 +80,8 @@ export default function BadgeOwnedPreview() {
   const creatorAddress = badgeModel?.creator.id || '0x'
   const creatorResponse = useUserById(creatorAddress as WCAddress, contract)
   const creator = creatorResponse.data
-  const { badgeOpenseaUrl, badgePreviewUrl, shortPreviewURl } = useBadgePreviewUrl(
-    badgeId,
-    badge?.contractAddress,
-  )
+  const { badgeOpenseaUrl, badgePreviewUrl, shortPreviewShareableUrl, shortPreviewURl } =
+    useBadgePreviewUrl(badgeId, badge?.contractAddress)
   const requiredBadgeDataMetadata = useBadgeThirdPartyRequiredData(
     `${badgeId}` || '',
     badge?.contractAddress,
@@ -158,7 +156,7 @@ export default function BadgeOwnedPreview() {
       <Stack alignItems="center">
         <BadgeView
           additionalData={{ ...values }}
-          badgeUrl={badgePreviewUrl}
+          badgeUrl={shortPreviewURl}
           modelId={badgeModel.id}
         />
       </Stack>
@@ -224,7 +222,7 @@ export default function BadgeOwnedPreview() {
               <Tooltip arrow title={t('badge.viewBadge.shareTwitter')}>
                 <TwitterShareButton
                   related={['@thebadgexyz']}
-                  url={generateTwitterText(badgeModelName, shortPreviewURl)}
+                  url={generateTwitterText(badgeModelName, shortPreviewShareableUrl)}
                 >
                   <XIcon round size={32} />
                 </TwitterShareButton>

--- a/src/pagePartials/badge/preview/DiplomaOwnedPreview.tsx
+++ b/src/pagePartials/badge/preview/DiplomaOwnedPreview.tsx
@@ -184,7 +184,7 @@ export default function DiplomaOwnedPreview() {
                   <IconButton
                     aria-label="Share badge preview"
                     component="label"
-                    onClick={() => handleShare()}
+                    onClick={() => handleShare(shortPreviewShareableUrl)}
                   >
                     <ShareOutlinedIcon />
                   </IconButton>

--- a/src/pagePartials/badge/preview/DiplomaOwnedPreview.tsx
+++ b/src/pagePartials/badge/preview/DiplomaOwnedPreview.tsx
@@ -83,11 +83,8 @@ export default function DiplomaOwnedPreview() {
   const creator = creatorResponse.data
   const creatorMetadata = useUserMetadata(creator?.id, creator?.metadataUri || '')
   const requiredBadgeDataMetadata = useBadgeThirdPartyRequiredData(`${badgeId}` || '', contract)
-  const { badgeOpenseaUrl, badgePreviewUrl, shortPreviewURl } = useBadgePreviewUrl(
-    badge?.id || '',
-    badge?.contractAddress || '',
-    readOnlyChainId,
-  )
+  const { badgeOpenseaUrl, badgePreviewUrl, shortPreviewShareableUrl, shortPreviewURl } =
+    useBadgePreviewUrl(badge?.id || '', badge?.contractAddress || '', readOnlyChainId)
   const badgeModelName = badgeModel?.badgeModelMetadata?.name || ''
 
   if (!badge || !badgeModel) {
@@ -156,7 +153,7 @@ export default function DiplomaOwnedPreview() {
         <Stack style={isMobile ? { display: 'block', maxHeight: '220px' } : { flex: 2, gap: 3 }}>
           <DiplomaView
             additionalData={{ ...values }}
-            badgeUrl={badgePreviewUrl}
+            badgeUrl={shortPreviewURl}
             modelId={badgeModel.id}
           />
         </Stack>
@@ -219,7 +216,7 @@ export default function DiplomaOwnedPreview() {
                 <Tooltip arrow title={t('badge.viewBadge.shareTwitter')}>
                   <TwitterShareButton
                     related={['@thebadgexyz']}
-                    url={generateTwitterText(badgeModelName, shortPreviewURl)}
+                    url={generateTwitterText(badgeModelName, shortPreviewShareableUrl)}
                   >
                     <XIcon round size={32} />
                   </TwitterShareButton>

--- a/src/utils/navigation/generateUrl.ts
+++ b/src/utils/navigation/generateUrl.ts
@@ -57,6 +57,24 @@ export function generateBadgePreviewUrl(
   }
 }
 
+/**
+ *  Helper function that generates a shareable url, using the new route that has metadata
+ * @param badgeId
+ * @param extraParams - Use contractValue if you already have the queryParam
+ * value, if not you can provided chain and contract address individually
+ */
+export function generateBadgePreviewShareableUrl(
+  badgeId: string,
+  extraParams: ChainAgnosticParams | { contractValue: string },
+) {
+  if ('contractValue' in extraParams) {
+    return `/preview/${badgeId}?contract=${extraParams.contractValue}`
+  } else {
+    const { connectedChainId, theBadgeContractAddress } = extraParams
+    return `/preview/${badgeId}?contract=${connectedChainId}:${theBadgeContractAddress}`
+  }
+}
+
 export function generateProfileUrl(args?: {
   address?: string
   filter?: string


### PR DESCRIPTION
# Description

Use the new path to share badges on twitter  to display metadata and also use the `shortUrl` on QR code
